### PR TITLE
Fix Storybook CI step invoking wrong npm script

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -76,7 +76,7 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
         working-directory: ${{ env.BUILD_PATH }}
       - name: Build Storybook style guide
-        run: ${{ steps.detect-package-manager.outputs.runner }} storybook build --output-dir public/styleguide
+        run: ${{ steps.detect-package-manager.outputs.runner }} storybook:build
         working-directory: ${{ env.BUILD_PATH }}
       - name: Build with Astro
         run: |


### PR DESCRIPTION
## Summary

- Fixes the "Build Storybook style guide" CI step in `astro.yml`

## Root cause

The step ran `pnpm storybook build --output-dir public/styleguide`. Because `storybook` is defined in `package.json` as `storybook dev -p 6006`, pnpm expanded it to `storybook dev -p 6006 build --output-dir public/styleguide` — passing `build` as an unknown option to the dev server command.

## Fix

Changed to `pnpm storybook:build`, which maps directly to `storybook build --output-dir public/styleguide`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgBsw219iQB1xJVRdwbkxN)_